### PR TITLE
New event types

### DIFF
--- a/src/events.mjs
+++ b/src/events.mjs
@@ -67,10 +67,11 @@ const getKickOffCalender = async (auth) => {
 let sheetEvents = {};
 let kickOffEvents = [];
 const syncEvents = async () => {
-    await authorize().then(async auth => {
-        sheetEvents = await getEventsFromSheet(auth);
-        kickOffEvents = await getKickOffCalender(auth);
-    }).catch(console.error);
+    if (process.env.ENABLE_DRIVE == "true")
+        await authorize().then(async auth => {
+            sheetEvents = await getEventsFromSheet(auth);
+            kickOffEvents = await getKickOffCalender(auth);
+        }).catch(console.error);
 };
 
 let lastTime = new Date(Date.parse("2100-01-01"));

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -69,7 +69,10 @@ const getSheetEvents = async (req, res) => {
 };
 
 const getKickOffEvents = async (req, res) => {
-    getter(req, res, () => kickOffEvents);
+    getter(req, res, () => {
+        console.log(req.query.type);
+        return kickOffEvents;
+    });
 };
 
 export { getSheetEvents, getKickOffEvents };

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -46,6 +46,13 @@ const getKickOffCalender = async (auth) => {
         } else {
             o.group = "all";
         }
+        o.dateData = {
+            start: new Date(Date.parse(o.start.date ? o.start.date : o.start.dateTime)),
+            end: new Date(Date.parse(o.end.date ? o.end.date : o.end.dateTime)),
+            isDay: o.start.dateTime == null && o.end.dateTime == null
+        };
+        delete o.start;
+        delete o.end;
         o.committee = o.summary.match(committeeRegex)
             ? o.summary.match(committeeRegex)[0].slice(1, -1)
             : "DVD";

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -48,8 +48,9 @@ const syncEvents = async () => {
     }).catch(console.error);
 };
 
-let lastTime = Number.MAX_VALUE;
-const getSheetEvents = async (req, res) => {
+let lastTime = new Date(Date.parse("2100-01-01"));
+
+const getter = async (req, res, getter) => {
     if (process.env.ENABLE_DRIVE != "true") {
         res.json({ error: "Event API is down!" });
         return;
@@ -60,21 +61,15 @@ const getSheetEvents = async (req, res) => {
         lastTime = new Date();
         await syncEvents();
     }
-    res.json(sheetEvents);
+    res.json(getter());
+};
+
+const getSheetEvents = async (req, res) => {
+    getter(req, res, () => sheetEvents);
 };
 
 const getKickOffEvents = async (req, res) => {
-    if (process.env.ENABLE_DRIVE != "true") {
-        res.json({ error: "Event API is down!" });
-        return;
-    }
-    const diff = Math.abs(new Date() - lastTime);
-    const minutes = (diff / 1000) / 60;
-    if (minutes >= 5) {
-        lastTime = new Date();
-        await syncEvents();
-    }
-    res.json(kickOffEvents);
+    getter(req, res, () => kickOffEvents);
 };
 
 export { getSheetEvents, getKickOffEvents };

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -15,7 +15,6 @@ const getEventsFromSheet = async (auth) => {
         let obj = {};
         headers.forEach((h, i) => obj[h] = val[i]);
         const formattedTime = obj["Day"] + ":" + obj["Time"].replace(".", ":");
-        //console.log(formattedTime + ": " + Date.parse(formattedTime));
         obj.FullTime = Date.parse(formattedTime);
         return obj;
     });
@@ -33,7 +32,14 @@ const getKickOffCalender = async (auth) => {
         singleEvents: true,
         orderBy: "startTime",
     });
-    const events = res.data.items;
+    const committeeRegex = /\((\w+|[0,9]|\+|å|ä|ö|Å|Ä|Ö| |&|\.|!|\t)+\)( *$)/;
+    const events = res.data.items.map(o => {
+        o.committee = o.summary.match(committeeRegex)
+            ? o.summary.match(committeeRegex)[0].slice(1, -1)
+            : "DVD";
+        o.summary = o.summary.replace(committeeRegex, "");
+        return o;
+    });
     return events;
 };
 
@@ -41,10 +47,8 @@ let sheetEvents = {};
 let kickOffEvents = [];
 const syncEvents = async () => {
     authorize().then(async auth => {
-        const data = await getEventsFromSheet(auth);
-        sheetEvents = data;
-        const kickOff = await getKickOffCalender(auth);
-        kickOffEvents = kickOff;
+        sheetEvents = await getEventsFromSheet(auth);
+        kickOffEvents = await getKickOffCalender(auth);
     }).catch(console.error);
 };
 
@@ -70,8 +74,14 @@ const getSheetEvents = async (req, res) => {
 
 const getKickOffEvents = async (req, res) => {
     getter(req, res, () => {
-        console.log(req.query.type);
-        return kickOffEvents;
+        const query = req.query.type;
+        if (query === "bachelor") {
+
+        }
+        else if (query === "master") {
+
+        }
+        else return kickOffEvents;
     });
 };
 

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -1,31 +1,10 @@
 import { authorize } from "./googleApi.mjs";
 import { google } from "googleapis";
 
-const getEventsFromSheet = async (auth) => {
-    const sheet = google.sheets({ version: "v4", auth: auth });
-    const data = await sheet.spreadsheets.values.get({
-        spreadsheetId: "1E35HVlMfHw9wKmfgHr982yGe_lIyTQxMhd-jNh2uIOg",
-        range: "Formulärsvar 1!A1:L",
-    });
-    let values = data.data.values;
-    let headers = values[0];
-    values.shift();
-    values = values.map(val => {
-        let obj = {};
-        headers.forEach((h, i) => obj[h] = val[i]);
-        const formattedTime = obj["Day"] + ":" + obj["Time"].replace(".", ":");
-        obj.FullTime = Date.parse(formattedTime);
-        return obj;
-    });
-    values.sort((a, b) => a.FullTime - b.FullTime);
-
-    return values;
-};
-
-const getKickOffCalender = async (auth) => {
+const getKickOffCalender = async (auth, calenderId) => {
     const calendar = google.calendar({ version: "v3", auth });
     const res = await calendar.events.list({
-        calendarId: "c_18d270d79e0911aa0be7a499c2190b616bbebf8462b3936d67cf4966757db7cb@group.calendar.google.com",
+        calendarId: calenderId,
         timeMin: new Date().toISOString(),
         maxResults: 100,
         singleEvents: true,
@@ -70,19 +49,17 @@ const getKickOffCalender = async (auth) => {
     return events;
 };
 
-let sheetEvents = {};
 let kickOffEvents = [];
-const syncEvents = async () => {
+const syncEvents = async (calenderId) => {
     if (process.env.ENABLE_DRIVE == "true")
         await authorize().then(async auth => {
-            sheetEvents = await getEventsFromSheet(auth);
-            kickOffEvents = await getKickOffCalender(auth);
+            kickOffEvents = await getKickOffCalender(auth, calenderId);
         }).catch(console.error);
 };
 
 let lastTime = new Date(Date.parse("2100-01-01"));
 
-const getter = async (req, res, getter) => {
+const getter = async (req, res, calendarId, getter) => {
     if (process.env.ENABLE_DRIVE != "true") {
         res.json({ error: "Event API is down!" });
         return;
@@ -91,25 +68,23 @@ const getter = async (req, res, getter) => {
     const minutes = (diff / 1000) / 60;
     if (minutes >= 5) {
         lastTime = new Date();
-        syncEvents().then(() => res.json(getter()));
+        syncEvents(calendarId).then(() => res.json(getter()));
     } else res.json(getter());
 };
 
-const getSheetEvents = async (req, res) => {
-    getter(req, res, () => sheetEvents);
-};
-
 const getKickOffEvents = async (req, res) => {
-    getter(req, res, () => {
-        const query = req.query.type;
-        if (query) {
-            return kickOffEvents.filter(
-                e => e.group.includes(query)
-                    || e.group.length == 0
-            );
-        }
-        else return kickOffEvents;
-    });
+    getter(req, res,
+        "c_18d270d79e0911aa0be7a499c2190b616bbebf8462b3936d67cf4966757db7cb@group.calendar.google.com",
+        () => {
+            const query = req.query.type;
+            if (query) {
+                return kickOffEvents.filter(
+                    e => e.group.includes(query)
+                        || e.group.length == 0
+                );
+            }
+            else return kickOffEvents;
+        });
 };
 
-export { getSheetEvents, getKickOffEvents };
+export { getKickOffEvents };

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -34,7 +34,7 @@ const getKickOffCalender = async (auth) => {
     const committeeRegex = /\((\w+|[0,9]|\+|å|ä|ö|Å|Ä|Ö| |&|\.|!|\t)+\)( *$)/g;
     const groupRegex = /\[(\w+|[0,9]|\+|å|ä|ö|Å|Ä|Ö| |&|\.|!|\t)+\]/g;
     const events = res.data.items.map(o => {
-        //TODO Replace this with a more general approach once testing data is available
+        // Get the target groups for an event
         o.group = [];
         const groupMatch = o.summary.match(groupRegex);
         if (groupMatch) groupMatch.map(e => o.group.push(e.slice(1, -1)));

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -33,11 +33,25 @@ const getKickOffCalender = async (auth) => {
         orderBy: "startTime",
     });
     const committeeRegex = /\((\w+|[0,9]|\+|å|ä|ö|Å|Ä|Ö| |&|\.|!|\t)+\)( *$)/;
+    const group = /\[(\w+|[0,9]|\+|å|ä|ö|Å|Ä|Ö| |&|\.|!|\t)+\]/;
     const events = res.data.items.map(o => {
+        //TODO Replace this with a more general approach once testing data is available
+        if (o.summary.includes("[Kandidat]")
+            && o.summary.includes("[Master]")) {
+            o.group = "all";
+        } else if (o.summary.includes("[Kandidat]")) {
+            o.group = "bachelor";
+        } else if (o.summary.includes("[Master]")) {
+            o.group = "master";
+        } else {
+            o.group = "all";
+        }
         o.committee = o.summary.match(committeeRegex)
             ? o.summary.match(committeeRegex)[0].slice(1, -1)
             : "DVD";
-        o.summary = o.summary.replace(committeeRegex, "");
+        o.summary = o.summary
+            .replace(committeeRegex, "")
+            .replace(group, "");
         return o;
     });
     return events;

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -102,11 +102,11 @@ const getSheetEvents = async (req, res) => {
 const getKickOffEvents = async (req, res) => {
     getter(req, res, () => {
         const query = req.query.type;
-        if (query === "bachelor") {
-            return kickOffEvents;
-        }
-        else if (query === "master") {
-            return kickOffEvents;
+        if (query) {
+            return kickOffEvents.filter(
+                e => e.group.includes(query)
+                    || e.group.length == 0
+            );
         }
         else return kickOffEvents;
     });

--- a/src/events.mjs
+++ b/src/events.mjs
@@ -67,7 +67,7 @@ const getKickOffCalender = async (auth) => {
 let sheetEvents = {};
 let kickOffEvents = [];
 const syncEvents = async () => {
-    authorize().then(async auth => {
+    await authorize().then(async auth => {
         sheetEvents = await getEventsFromSheet(auth);
         kickOffEvents = await getKickOffCalender(auth);
     }).catch(console.error);
@@ -84,9 +84,8 @@ const getter = async (req, res, getter) => {
     const minutes = (diff / 1000) / 60;
     if (minutes >= 5) {
         lastTime = new Date();
-        await syncEvents();
-    }
-    res.json(getter());
+        syncEvents().then(() => res.json(getter()));
+    } else res.json(getter());
 };
 
 const getSheetEvents = async (req, res) => {
@@ -97,10 +96,10 @@ const getKickOffEvents = async (req, res) => {
     getter(req, res, () => {
         const query = req.query.type;
         if (query === "bachelor") {
-
+            return kickOffEvents;
         }
         else if (query === "master") {
-
+            return kickOffEvents;
         }
         else return kickOffEvents;
     });

--- a/src/photos.mjs
+++ b/src/photos.mjs
@@ -66,9 +66,9 @@ const buildTree = async (files) => {
 };
 
 let photos = null;
-const syncPhotos = () => {
+const syncPhotos = async () => {
     if (process.env.ENABLE_DRIVE == "true")
-        authorize().then(async c => {
+        await authorize().then(async c => {
             photos = await buildTree(await listFiles(c));
         }).catch(console.error);
 };
@@ -84,9 +84,8 @@ const getPhotos = async (req, res) => {
     const minutes = (diff / 1000) / 60;
     if (minutes >= 5) {
         lastTime = new Date();
-        await syncPhotos();
-    }
-    res.json(photos);
+        syncPhotos().then(() => res.json(photos));
+    } else res.json(photos);
 };
 
 export default getPhotos;

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -16,7 +16,7 @@ const callback = (req, res) => {
 import { newsfeed } from "./newsfeed.mjs";
 import { postHook } from "./githookhandle.mjs";
 import getPhotos from "./photos.mjs";
-import { getKickOffEvents } from "./events.mjs";
+import { getKickOffEvents, getDVEvents } from "./events.mjs";
 import killerBean from "./killerbean.mjs";
 
 app.use(expressStaticGzip("dist", {
@@ -47,6 +47,7 @@ app.get("/committees/dvrk/master", callback);
 app.get("/newsfeed", newsfeed);
 app.get("/getPhotos", getPhotos);
 app.get("/getKickoffEvents", getKickOffEvents);
+app.get("/getEvents", getDVEvents);
 app.post("/postHook", postHook);
 app.post("/killerBean", killerBean);
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -30,6 +30,7 @@ app.get("/documents", callback);
 app.get("/contact", callback);
 app.get("/tools", callback);
 app.get("/photos", callback);
+app.get("/schedule", callback);
 app.get("/committees/the-board", callback);
 app.get("/committees/dvrk", callback);
 app.get("/committees/dvrk/schedule", callback);

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -16,7 +16,7 @@ const callback = (req, res) => {
 import { newsfeed } from "./newsfeed.mjs";
 import { postHook } from "./githookhandle.mjs";
 import getPhotos from "./photos.mjs";
-import { getSheetEvents, getKickOffEvents } from "./events.mjs";
+import { getKickOffEvents } from "./events.mjs";
 import killerBean from "./killerbean.mjs";
 
 app.use(expressStaticGzip("dist", {
@@ -46,7 +46,6 @@ app.get("/committees/dvrk/bachelor", callback);
 app.get("/committees/dvrk/master", callback);
 app.get("/newsfeed", newsfeed);
 app.get("/getPhotos", getPhotos);
-app.get("/getEvents", getSheetEvents);
 app.get("/getKickoffEvents", getKickOffEvents);
 app.post("/postHook", postHook);
 app.post("/killerBean", killerBean);

--- a/src/www/app.jsx
+++ b/src/www/app.jsx
@@ -12,6 +12,7 @@ import HomePage from "./components/home-page";
 import CommitteePage from "./components/committee-page";
 import ToolsPage from "./components/tools-page";
 import PhotosPage from "./components/photos-page";
+import Schedule from "./components/widgets/schedule";
 // import WIP from "./components/widgets/wip";
 import IndividualCommitteePage from "./components/individual-committee-page";
 
@@ -37,6 +38,12 @@ const App = () => {
             <Route exact path="/documents" element={<DocumentPage />} />
             <Route exact path="/contact" element={<ContactPage />} />
             <Route exact path="/photos" element={<PhotosPage />} />
+            <Route exact path="/schedule" element={
+              <div className="page">
+                <h1>Event</h1>
+                <Schedule eventUrl="/getEvents" full={true} />
+              </div>
+            } />
 
             <Route exact path="/committees/the-board" element={
               <IndividualCommitteePage text={require("../../content/committees/the-board.md")["default"]} />

--- a/src/www/components/dvrk-page.jsx
+++ b/src/www/components/dvrk-page.jsx
@@ -66,7 +66,7 @@ const DVRKbar = () => {
 
 const MainPage = () => (
     <>
-        <Schedule eventUrl="/getKickOffEvents" />
+        <Schedule eventUrl="/getKickOffEvents" restUrl="/committees/dvrk/schedule" />
         <ReactMarkdown children={text} rehypePlugins={[rehypeRaw]} remarkPlugins={[remarkGfm]}></ReactMarkdown>
     </>
 );

--- a/src/www/components/dvrk-page.jsx
+++ b/src/www/components/dvrk-page.jsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import text from "../../../content/committees/dvrk.md";
-import KickoffSchedule from "./widgets/kickoff-schedule";
+import Schedule from "./widgets/schedule";
 import "./../dvrk-styles.less";
 import { Route, Link, useNavigate } from "react-router-dom";
 import DVRKLogo from "../../../assets/committee-logos/dvrk-logo.png";
@@ -66,14 +66,14 @@ const DVRKbar = () => {
 
 const MainPage = () => (
     <>
-        <KickoffSchedule />
+        <Schedule eventUrl="/getKickOffEvents" />
         <ReactMarkdown children={text} rehypePlugins={[rehypeRaw]} remarkPlugins={[remarkGfm]}></ReactMarkdown>
     </>
 );
 
 const SchedulePage = () => (
     <>
-        <KickoffSchedule full={true} />
+        <Schedule full={true} eventUrl="/getKickoffEvents" />
     </>
 );
 

--- a/src/www/components/home-page.jsx
+++ b/src/www/components/home-page.jsx
@@ -11,8 +11,8 @@ import { isReception } from "../util";
 
 const me = () => (
     <div className="page">
-        <ReactMarkdown children={text} rehypePlugins={[rehypeRaw]} remarkPlugins={[remarkGfm]}></ReactMarkdown>
         <KickoffInfoButton />
+        <ReactMarkdown children={text} rehypePlugins={[rehypeRaw]} remarkPlugins={[remarkGfm]}></ReactMarkdown>
         {!isReception()
             ?
             <>

--- a/src/www/components/home-page.jsx
+++ b/src/www/components/home-page.jsx
@@ -6,10 +6,12 @@ import text from "../../../content/home-page.md";
 import InfoButton from "./widgets/info-button.jsx";
 import KickoffInfoButton from "./widgets/kickoff-info-button";
 import NewsFeed from "./widgets/newsfeed";
+import Schedule from "./widgets/schedule";
 
 const me = () => (
     <div className="page">
         <KickoffInfoButton />
+        <Schedule eventUrl="/getEvents" restUrl="/schedule" />
         <ReactMarkdown children={text} rehypePlugins={[rehypeRaw]} remarkPlugins={[remarkGfm]}></ReactMarkdown>
 
         <NewsFeed />

--- a/src/www/components/home-page.jsx
+++ b/src/www/components/home-page.jsx
@@ -7,12 +7,19 @@ import InfoButton from "./widgets/info-button.jsx";
 import KickoffInfoButton from "./widgets/kickoff-info-button";
 import NewsFeed from "./widgets/newsfeed";
 import Schedule from "./widgets/schedule";
+import { isReception } from "../util";
 
 const me = () => (
     <div className="page">
-        <KickoffInfoButton />
-        <Schedule eventUrl="/getEvents" restUrl="/schedule" />
         <ReactMarkdown children={text} rehypePlugins={[rehypeRaw]} remarkPlugins={[remarkGfm]}></ReactMarkdown>
+        <KickoffInfoButton />
+        {!isReception()
+            ?
+            <>
+                <h2>Events</h2>
+                <Schedule eventUrl="/getEvents" restUrl="/schedule" />
+            </>
+            : <></>}
 
         <NewsFeed />
         {/* <div className="info-buttons-list">

--- a/src/www/components/widgets/kickoff-info-button.jsx
+++ b/src/www/components/widgets/kickoff-info-button.jsx
@@ -1,15 +1,19 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { isReception } from "../../util";
 
 const me = () => {
     const month = new Date().getMonth() + 1;
     //const action = () => window.open("https://dvrk.dvet.se");
     const nav = useNavigate();
     const action = () => nav("/committees/dvrk");
-    return month >= 6 && month <= 9 ? <button className="kickoff-info-button" onClick={action}>
-        <p>Letar du efter mottagningsinfo?</p>
-        <p>Tryck här!</p>
-    </button> : null;
+
+    return isReception()
+        ? <button className="kickoff-info-button" onClick={action}>
+            <p>Letar du efter mottagningsinfo?</p>
+            <p>Tryck här!</p>
+        </button>
+        : <></>;
 };
 
 export default me;

--- a/src/www/components/widgets/kickoff-schedule.jsx
+++ b/src/www/components/widgets/kickoff-schedule.jsx
@@ -62,27 +62,21 @@ const getEventData = async (full, openModal, setModalData) => {
             className += " upcoming";
         }
 
-        const lastParentheses = /\((\w+|[0,9]|\+|å|ä|ö|Å|Ä|Ö| |&|\.|!|\t)+\)( *$)/;
-        const committee = o.summary.match(lastParentheses)
-            ? o.summary.match(lastParentheses)[0].slice(1, -1)
-            : "DVD";
-        const summary = o.summary.replace(lastParentheses, "");
-
         const location = o.location
             ? o.location.split(",").slice(0, 2).join(", ")
             : <>&nbsp;</>;
 
         if (o.description) className += " clickable";
         const action = (o.description) ? () => {
-            setModalData([summary, o.description, dateElem, committee, location]);
+            setModalData([o.summary, o.description, dateElem, o.committee, location]);
             openModal();
         } : () => { };
 
         return <div className={className} onClick={action}>
-            <h3>{summary}</h3>
+            <h3>{o.summary}</h3>
             <h4>{dateElem}</h4>
             <h4>{location}</h4>
-            <p>Arrangör: {committee}</p>
+            <p>Arrangör: {o.committee}</p>
         </div>;
     });
     if (full !== true) {

--- a/src/www/components/widgets/kickoff-schedule.jsx
+++ b/src/www/components/widgets/kickoff-schedule.jsx
@@ -16,11 +16,8 @@ const getEventData = async (full, openModal, setModalData) => {
     const json = await (await fetch("/getKickOffEvents")).json();
     let data = json
         .map(o => {
-            o.dateData = {
-                start: new Date(Date.parse(o.start.date ? o.start.date : o.start.dateTime)),
-                end: new Date(Date.parse(o.end.date ? o.end.date : o.end.dateTime)),
-                isDay: o.start.dateTime == null && o.end.dateTime == null
-            };
+            o.dateData.start = new Date(Date.parse(o.dateData.start));
+            o.dateData.end = new Date(Date.parse(o.dateData.end));
             return o;
         })
         .filter(o => {

--- a/src/www/components/widgets/schedule.jsx
+++ b/src/www/components/widgets/schedule.jsx
@@ -12,8 +12,8 @@ const isToday = (date) => {
 const hasPassed = (date) => (date < new Date());
 
 const EVENT_LIMIT = 5;
-const getEventData = async (full, openModal, setModalData) => {
-    const json = await (await fetch("/getKickOffEvents")).json();
+const getEventData = async (full, eventUrl, openModal, setModalData) => {
+    const json = await (await fetch(eventUrl)).json();
     let data = json
         .map(o => {
             o.dateData.start = new Date(Date.parse(o.dateData.start));
@@ -106,7 +106,7 @@ const me = (props) => {
 
     const [csv, setState] = React.useState(<div className="loading"></div>);
     React.useEffect(() => {
-        getEventData(props.full, openModal, setModalData).then((res) => setState(res));
+        getEventData(props.full, props.eventUrl, openModal, setModalData).then((res) => setState(res));
     }, [getEventData]);
 
     // const backButton = (props.full == true) ?

--- a/src/www/components/widgets/schedule.jsx
+++ b/src/www/components/widgets/schedule.jsx
@@ -115,7 +115,7 @@ const me = (props) => {
 
     const month = new Date().getMonth() + 1;
 
-    return (month >= 6 && month <= 9) || props.full == true ? <div className="schedule-holder">
+    return props.full == true ? <div className="schedule-holder">
         {csv}
         <Modal
             isOpen={modalIsOpen}

--- a/src/www/components/widgets/schedule.jsx
+++ b/src/www/components/widgets/schedule.jsx
@@ -115,7 +115,7 @@ const me = (props) => {
 
     const month = new Date().getMonth() + 1;
 
-    return props.full == true ? <div className="schedule-holder">
+    return <div className="schedule-holder">
         {csv}
         <Modal
             isOpen={modalIsOpen}
@@ -133,7 +133,7 @@ const me = (props) => {
             <p>Vilka hostar: {modalWho}</p>
             <button onClick={closeModal} className="close-button">X</button>
         </Modal>
-    </div> : <></>;
+    </div>;
 };
 
 export default me;

--- a/src/www/components/widgets/schedule.jsx
+++ b/src/www/components/widgets/schedule.jsx
@@ -12,7 +12,7 @@ const isToday = (date) => {
 const hasPassed = (date) => (date < new Date());
 
 const EVENT_LIMIT = 5;
-const getEventData = async (full, eventUrl, openModal, setModalData) => {
+const getEventData = async (full, eventUrl, restUrl, openModal, setModalData) => {
     const json = await (await fetch(eventUrl)).json();
     let data = json
         .map(o => {
@@ -30,6 +30,7 @@ const getEventData = async (full, eventUrl, openModal, setModalData) => {
                 return true;
             }
         });
+    const hidingEvents = data.length > EVENT_LIMIT;
     if (full !== true) {
         data = data.slice(0, EVENT_LIMIT);
     }
@@ -76,11 +77,11 @@ const getEventData = async (full, eventUrl, openModal, setModalData) => {
             <p>Arrangör: {o.committee}</p>
         </div>;
     });
-    if (full !== true) {
+    if (full !== true && hidingEvents) {
         data.push(
             <div
                 className="schedule-item upcoming-button"
-                onClick={() => window.open("/committees/dvrk/schedule", "_self")}
+                onClick={() => window.open(restUrl, "_self")}
             >
                 <h3>Uppkommande</h3>
                 <p> Tryck här för att se resten av eventen!</p>
@@ -106,33 +107,20 @@ const me = (props) => {
 
     const [csv, setState] = React.useState(<div className="loading"></div>);
     React.useEffect(() => {
-        getEventData(props.full, props.eventUrl, openModal, setModalData).then((res) => setState(res));
+        getEventData(
+            props.full, props.eventUrl,
+            props.restUrl, openModal, setModalData
+        ).then((res) => setState(res));
     }, [getEventData]);
-
-    // const backButton = (props.full == true) ?
-    //     <button onClick={() => {
-    //         const events = Array.from(document.getElementsByClassName("passed"));
-    //         if (!oldVisible) {
-    //             events.forEach(x => x.classList.remove("hidden"));
-    //             oldVisible = true;
-    //         }
-    //         else {
-    //             events.forEach(x => x.classList.add("hidden"));
-    //             oldVisible = false;
-    //         }
-    //     }}>Toggla tidigare event</button>
-    //     : <></>;
 
     const month = new Date().getMonth() + 1;
 
     return (month >= 6 && month <= 9) || props.full == true ? <div className="schedule-holder">
-        {/* {backButton} */}
         {csv}
         <Modal
             isOpen={modalIsOpen}
             onAfterOpen={afterOpenModal}
             onRequestClose={closeModal}
-            //style={customStyles}
             contentLabel="Example Modal"
             appElement={document.getElementById("app")}
             className="schedule-modal"

--- a/src/www/styles.less
+++ b/src/www/styles.less
@@ -253,6 +253,7 @@ code {
     border: none;
     box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.5);
     transition-duration: 100ms;
+    margin-bottom: 20px;
 }
 
 .kickoff-info-button:hover {

--- a/src/www/util.js
+++ b/src/www/util.js
@@ -1,0 +1,8 @@
+const isReception = () => {
+    const fromDate = new Date(Date.parse(`${new Date().getFullYear()}-07-13`));
+    const toDate = new Date(Date.parse(`${new Date().getFullYear()}-09-16`));
+    return (new Date().getDate() >= fromDate.getDate())
+        && (new Date().getDate() <= toDate.getDate());
+};
+
+export { isReception };


### PR DESCRIPTION
Extended the calendar Api, allowing hosts to input target groups such as [Kandidat] or [Master] in their event title, which the Api automatically parses to allow for event filtering.
Made the kick-off schedule more generic, allowing it to be easily used with other calendars, which in turn led to adding a general DV calendar to the front page of the site.

Also redid the check if it is appropriate to show kick-off info, which is now used to either show a link to the kick-off info or the general DV calendar on the home page, depending on if we are currently in the reception.

https://dvet.se/getKickOffEvents can be used to get kick-off events, and
https://dvet.se/getEvents can be used to get general events.

Follow these addresses with the parameter `?type=<Group>`( `?type=Kandidat` for example), to only get events that target all groups or the `Kandidat` group.

(also removed the Sheets based address as that was kinda useless compared to the calender setup :wolf:)