### PR TITLE
Make only the concats commitee bade use pixelated image rendering

### DIFF
--- a/src/www/components/committee-page.jsx
+++ b/src/www/components/committee-page.jsx
@@ -26,7 +26,7 @@ const me = () => (
       <CommitteeBadge uri="/committees/dvrk" name="DVRK" logo={DVRKLogo} color="#1e1e1e" />
       <CommitteeBadge uri="/committees/board-of-studies" name={isEnglish() ? "Board of Studies" : "Studienämnd"} fontSize="1.8em" logo={BoardOfStudies} />
       <CommitteeBadge uri="/committees/mega6" name="Mega6" logo={Mega6Logo} />
-      <CommitteeBadge uri="/committees/concats" imageText={ConCatsText} logo={ConCatsLogo} />
+      <CommitteeBadge uri="/committees/concats" imageText={ConCatsText} logo={ConCatsLogo} Concats={true}/>
       <CommitteeBadge uri="/committees/femmepp" name="Femme++" logo={FemmePPLogo} />
       <CommitteeBadge uri="/committees/dv_ops" name="DV_Ops" logo={DV_OpsLogo} DVops={true} />
       <CommitteeBadge uri="/committees/dvarm" name="DVArm" logo={DVArmLogo} />

--- a/src/www/components/widgets/committee-badge.jsx
+++ b/src/www/components/widgets/committee-badge.jsx
@@ -28,6 +28,10 @@ const me = (props) => {
         textholder += " dvOps-holder"
         imageholder += " dvOps-holder"
     }
+    if (props.Concats === true){
+        textholder += " concats-holder"
+        imageholder += " concats-holder"
+    }
 
     return <div className="committee-badge" style={style(props.color)} onClick={clickAction}>
         <div className= {imageholder}>

--- a/src/www/styles.less
+++ b/src/www/styles.less
@@ -903,10 +903,6 @@ code {
             display: flex;
             align-items: center;
             justify-content: center;
-
-            >img {
-                image-rendering: pixelated;
-            }
         }
 
         transition-duration: 0.25s;
@@ -945,10 +941,15 @@ code {
             }
 
             >img {
-                image-rendering: pixelated;
                 margin: auto;
                 margin-top: 24px;
                 margin-bottom: 24px;
+            }
+        }
+
+        .concats-holder {
+            >img {
+                image-rendering: pixelated;
             }
         }
 


### PR DESCRIPTION
The current style forces pixelated image rendering on all commitee badges. This results in poor scaling quality when downscaling other badges.

Old scaling:
![Screenshot 2024-07-01 181826](https://github.com/Datavetenskapsdivisionen/dvet.se/assets/1492697/3e634bff-54ed-4694-aa81-c1850a4b11b1)

New scaling:
![Screenshot 2024-07-01 181837](https://github.com/Datavetenskapsdivisionen/dvet.se/assets/1492697/f5d7edb9-4b27-4272-91aa-463892631d28)
