### PR TITLE
Add links to the Google Calenders to our calenders

### DIFF
--- a/src/www/components/dvrk-page.jsx
+++ b/src/www/components/dvrk-page.jsx
@@ -159,11 +159,18 @@ const ContactPage = () => {
 };
 
 const SchedulePage = (props) => {
+    const openUri = () => {
+        window.open("https://calendar.google.com/calendar/embed?src=c_18d270d79e0911aa0be7a499c2190b616bbebf8462b3936d67cf4966757db7cb%40group.calendar.google.com&ctz=Europe%2FStockholm", "_blank");
+    };
     return (
         <>
             <ContentHolder element={
                 <>
-                    <h1>{props.title ?? "Schedule"}</h1>
+                    <h1>{props.title ?? "Schedule"}
+                        <button className="calender-button" onClick={openUri}>
+                            <span>📅</span>
+                        </button>
+                    </h1>
                     <CalenderSchedule full={false} eventUrl={"/getKickoffEvents" + (props.extension ?? "")} />
                     {/* <Schedule full={true} eventUrl={"/getKickoffEvents" + (props.extension ?? "")} /> */}
                     <div style={{ height: "2em" }}></div>

--- a/src/www/components/home-page.jsx
+++ b/src/www/components/home-page.jsx
@@ -19,7 +19,14 @@ const me = () => (
         {!isReception()
             ?
             <>
-                <h2>Events</h2>
+                <h2>
+                    Events
+                    <button className="calender-button" onClick={() => {
+                        window.open("https://calendar.google.com/calendar/embed?src=c_cd70b7365c189248ae5fce47932c65729fb3a0a4052a83b610613f1e6dcfd047%40group.calendar.google.com&ctz=Europe%2FStockholm", "_blank");
+                    }}>
+                        <span>📅</span>
+                    </button>
+                </h2>
                 <Schedule eventLimit={2} />
             </>
             : <></>}

--- a/src/www/styles.less
+++ b/src/www/styles.less
@@ -1879,3 +1879,36 @@ nav {
     align-items: center;
     gap: 10px;
 }
+
+.calender-button {
+    position: relative;
+    background-color: black;
+    line-height: 1em;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    font-size: 1em;
+    margin-left: 10px;
+
+    span {
+        transition-duration: 0.2s;
+        filter: grayscale(100%);
+    }
+}
+
+.calender-button::after {
+    border: black 2px solid;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: -2px;
+    top: -2px;
+    content: "";
+    border-radius: 8px;
+}
+
+.calender-button:hover {
+    span {
+        filter: grayscale(0%)
+    }
+}


### PR DESCRIPTION
Simply adds two buttons which opens the Google Calendar for the main schedule and the reception schedule.


![image](https://github.com/user-attachments/assets/6522e2e7-56b8-4ece-abad-44c56bbefeba)

![image](https://github.com/user-attachments/assets/7eaf7a6c-39cf-49f6-82fe-7ae43a2ef4c7)


Looks pretty when hovered :)